### PR TITLE
secure DOIs

### DIFF
--- a/bib-search-crossref
+++ b/bib-search-crossref
@@ -1,4 +1,4 @@
 #!/bin/sh
 ./query.sh api.labs.crossref.org/search "$*" \
     | scrape.pl - span.doi span.title span.Z3988 \
-    | sed 's|^http://dx.doi.org/|doi:|'
+    | sed 's|^https://doi.org/|doi:|'


### PR DESCRIPTION
Hello @davidar :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update the code that generates new DOI links.

Cheers!